### PR TITLE
Bug fix for scenarios

### DIFF
--- a/lib/rspec/page-regression/file_paths.rb
+++ b/lib/rspec/page-regression/file_paths.rb
@@ -16,6 +16,7 @@ module RSpec::PageRegression
         (_#{Regexp.escape(expected_path.to_s)})?
           $
       }xi
+      descriptions.push example.description
       canonical_path = descriptions.map{|s| s.parameterize('_')}.inject(Pathname.new(""), &:+)
 
       app_root = Pathname.new(example.metadata[:file_path]).realpath.each_filename.take_while{|c| c != "spec"}.inject(Pathname.new("/"), &:+)


### PR DESCRIPTION
Scenario names were not being used in the image path breaking my tests.

Example test that is broken: https://github.com/jah2488/classroom/blob/aebf560f83a33fe2865b00c6763472ca1a85fd79/spec/features/cohort_spec.rb